### PR TITLE
Improved parser Performance

### DIFF
--- a/redis_clone/response_builder.py
+++ b/redis_clone/response_builder.py
@@ -46,9 +46,8 @@ class ResponseBuilder:
         """
         # Syntax of error is -<data>
         # So data is second element after error specifier
-        data = f"-{data}{PROTOCOL_SEPARATOR}"
-
-        return data.encode("utf-8")
+        data = b"-" + data.encode("utf-8") + PROTOCOL_SEPARATOR
+        return data
 
     def _build_protocol_2_simple_string(self, data):
         """
@@ -58,9 +57,8 @@ class ResponseBuilder:
         """
         # Syntax of simple string is +<data>
         # So data is second element after simple string specifier
-        data = f"+{data}{PROTOCOL_SEPARATOR}"
-
-        return data.encode("utf-8")
+        data = b"+" + data.encode("utf-8") + PROTOCOL_SEPARATOR
+        return data
 
     def _build_protocol_2_bulk_string(self, data):
         """
@@ -73,10 +71,11 @@ class ResponseBuilder:
 
         # If data is None then return nil value
         if data is None:
-            return f"${-1}{PROTOCOL_SEPARATOR}".encode("utf-8")
+            return b"$-1" + PROTOCOL_SEPARATOR
         else:
             # Syntax of bulk string is $<data length>
             # So data is second element after bulk string specifier
-            data = f"${len(data)}{PROTOCOL_SEPARATOR}{data}{PROTOCOL_SEPARATOR}"
+            length = str(len(data)).encode("utf-8")
+            data = b"$" + length + PROTOCOL_SEPARATOR + data.encode("utf-8") + PROTOCOL_SEPARATOR
 
-            return data.encode("utf-8")
+            return data

--- a/redis_clone/server.py
+++ b/redis_clone/server.py
@@ -57,8 +57,6 @@ class RedisServer:
                 break
 
             logger.info(f"Received data: {data}")
-            # Convert bytes to string
-            data = data.decode("utf-8")
             command_name, command_args = self.parser.parse_client_request(data)
             logger.info(f"Command name: {command_name}")
             logger.info(f"Command args: {command_args}")

--- a/tests/test_client_parser.py
+++ b/tests/test_client_parser.py
@@ -10,7 +10,7 @@ class TestParserClient:
         parser = Parser(protocol_version=2)
 
         # Test initial connection
-        test_str = "*1\r\n$7\r\nCOMMAND\r\n"
+        test_str = b"*1\r\n$7\r\nCOMMAND\r\n"
         command, args = self.parser.parse_client_request(test_str)
 
         assert command == "COMMAND"
@@ -21,7 +21,7 @@ class TestParserClient:
         Test SET command request
         """
         # Test initial connection
-        test_str = "*3\r\n$3\r\nSET\r\n$5\r\nmykey\r\n$7\r\nmyvalue\r\n"
+        test_str = b"*3\r\n$3\r\nSET\r\n$5\r\nmykey\r\n$7\r\nmyvalue\r\n"
         command, args = self.parser.parse_client_request(test_str)
 
         assert command == "SET"
@@ -32,7 +32,7 @@ class TestParserClient:
         Test GET command request
         """
         # Test initial connection
-        test_str = "*2\r\n$3\r\nGET\r\n$5\r\nmykey\r\n"
+        test_str = b"*2\r\n$3\r\nGET\r\n$5\r\nmykey\r\n"
         command, args = self.parser.parse_client_request(test_str)
 
         assert command == "GET"

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -16,7 +16,6 @@ def client():
 
 def test_ping(client):
     response = client.ping()
-    print(response)
     assert response == True
 
 


### PR DESCRIPTION
Main changes were reducing number of splits and directly do byte parsing instead of string parsing. Not a very huge improvement in performance but can see results after change:
eg: 
After change
```bash
$ redis-benchmark -p 9999 -t SET,GET -q
WARNING: Could not fetch server CONFIG
SET: 14440.43 requests per second, p50=3.247 msec
GET: 14587.89 requests per second, p50=3.247 msec
```

Before change
```bash
$ redis-benchmark -p 9999 -t SET,GET -q
WARNING: Could not fetch server CONFIG
SET: 13415.62 requests per second, p50=3.487 msec
GET: 13956.73 requests per second, p50=3.407 msec
```