### PR TITLE
Added support for subargs via metadata of commands

### DIFF
--- a/tests/test_client_parser.py
+++ b/tests/test_client_parser.py
@@ -20,7 +20,6 @@ class TestParserClient:
         """
         Test SET command request
         """
-        # Test initial connection
         test_str = b"*3\r\n$3\r\nSET\r\n$5\r\nmykey\r\n$7\r\nmyvalue\r\n"
         command, args = self.parser.parse_client_request(test_str)
 
@@ -31,12 +30,23 @@ class TestParserClient:
         """
         Test GET command request
         """
-        # Test initial connection
         test_str = b"*2\r\n$3\r\nGET\r\n$5\r\nmykey\r\n"
         command, args = self.parser.parse_client_request(test_str)
 
         assert command == "GET"
         assert args == ["mykey"]
+        
+    def test_subargs_parsing(self):
+        '''
+        Some commands in redis supports optional subargs.
+        eg: SET mykey myvalue EX 10 NX
+        '''
+        test_str = b"*6\r\n$3\r\nSET\r\n$5\r\nmykey\r\n$7\r\nmyvalue\r\n$2\r\nEX\r\n$2\r\n10\r\n$2\r\nNX\r\n"
+        command, args = self.parser.parse_client_request(test_str)
+        
+        print(args)
+        assert command == "SET"
+        assert args == ['mykey', 'myvalue', ('EX', '10'), ('NX', None)]
 
     def setup_method(self):
         self.parser = Parser(protocol_version=2)


### PR DESCRIPTION
Example:
Set might have following syntax: SET a 10 XX EX 10 

Parser should be able to parse these also accordingly. Using metadata dictionary to allow parsing of subargs. This metadata can be modified in future to allow adding more subargs for more commands.

```
The SET command supports a set of options that modify its behavior:

EX seconds -- Set the specified expire time, in seconds.
PX milliseconds -- Set the specified expire time, in milliseconds.
EXAT timestamp-seconds -- Set the specified Unix time at which the key will expire, in seconds.
PXAT timestamp-milliseconds -- Set the specified Unix time at which the key will expire, in milliseconds.
NX -- Only set the key if it does not already exist.
XX -- Only set the key if it already exists.
KEEPTTL -- Retain the time to live associated with the key.
GET -- Return the old string stored at key, or nil if key did not exist. An error is returned and SET aborted if the value stored at key is not a string.
```