### PR TITLE
Added expiration support and other options support for SET and delete support

### DIFF
--- a/redis_clone/redis_parser.py
+++ b/redis_clone/redis_parser.py
@@ -84,7 +84,9 @@ class Parser:
                     else:
                         raise Exception(f"Expected value for subargument {arg}, but none provided.")
                 else:
-                    command_args.append((arg, None))
+                    # Subargument does not take a value, so just append it to the command args.
+                    # Adding True as a placeholder value to indicate that the subargument is present.
+                    command_args.append((arg, True))
             
             else:
                 command_args.append(arg)

--- a/redis_clone/response_builder.py
+++ b/redis_clone/response_builder.py
@@ -25,18 +25,19 @@ class ResponseBuilder:
         else:
             raise Exception("Protocol version not supported")
 
-    def _build_protocol_2_response(self, type, data):
+    def _build_protocol_2_response(self, data_type, data):
         """
         Build response according to protocol version 2
         """
-        if type == Protocol_2_Data_Types.ERROR:
-            return self._build_protocol_2_error(data)
-        elif type == Protocol_2_Data_Types.SIMPLE_STRING:
-            return self._build_protocol_2_simple_string(data)
-        elif type == Protocol_2_Data_Types.BULK_STRING:
-            return self._build_protocol_2_bulk_string(data)
-        else:
-            raise Exception("Invalid protocol data type")
+        function_dict = {
+            Protocol_2_Data_Types.ERROR: self._build_protocol_2_error,
+            Protocol_2_Data_Types.SIMPLE_STRING: self._build_protocol_2_simple_string,
+            Protocol_2_Data_Types.BULK_STRING: self._build_protocol_2_bulk_string,
+            Protocol_2_Data_Types.INTEGER: self._build_protocol_2_integer,
+        }
+        if data_type not in function_dict:
+            raise Exception("Invalid response type")
+        return function_dict[data_type](data)
 
     def _build_protocol_2_error(self, data):
         """
@@ -79,3 +80,14 @@ class ResponseBuilder:
             data = b"$" + length + PROTOCOL_SEPARATOR + data.encode("utf-8") + PROTOCOL_SEPARATOR
 
             return data
+        
+    def _build_protocol_2_integer(self, data):
+        """
+        Integers are used in order to represent whole numbers between -(2^63) and 2^63-1.
+        They are encoded in the following way:
+        :<data>\r\n
+        """
+        # Syntax of integer is :<data>
+        # So data is second element after integer specifier
+        data = b":" + str(data).encode("utf-8") + PROTOCOL_SEPARATOR
+        return data

--- a/tests/test_client_parser.py
+++ b/tests/test_client_parser.py
@@ -46,7 +46,7 @@ class TestParserClient:
         
         print(args)
         assert command == "SET"
-        assert args == ['mykey', 'myvalue', ('EX', '10'), ('NX', None)]
+        assert args == ['mykey', 'myvalue', ('EX', '10'), ('NX', True)]
 
     def setup_method(self):
         self.parser = Parser(protocol_version=2)


### PR DESCRIPTION
Check https://redis.io/commands/del/ for DEL command.

```
The SET command supports a set of options that modify its behavior:

EX seconds -- Set the specified expire time, in seconds.
PX milliseconds -- Set the specified expire time, in milliseconds.
EXAT timestamp-seconds -- Set the specified Unix time at which the key will expire, in seconds.
PXAT timestamp-milliseconds -- Set the specified Unix time at which the key will expire, in milliseconds.
NX -- Only set the key if it does not already exist.
XX -- Only set the key if it already exists.
KEEPTTL -- Retain the time to live associated with the key.
GET -- Return the old string stored at key, or nil if key did not exist. An error is returned and SET aborted if the value stored at key is not a string.
```